### PR TITLE
Global, Object, Unicode pickle parsers

### DIFF
--- a/include/epryl_pickle.hrl
+++ b/include/epryl_pickle.hrl
@@ -1,0 +1,9 @@
+
+-record('$global',
+        {module :: binary(),                    % module name, eg "__builtin__"
+         name:: binary()}).                     % obj name, eg "filter"
+
+-record('$object',
+        {class :: #'$global'{},           % class
+         new_args :: tuple(),              % args for __new__()
+         state :: dict() | tuple()}).      % __dict__ or args for __setstate__()

--- a/include/epryl_pickle.hrl
+++ b/include/epryl_pickle.hrl
@@ -1,9 +1,12 @@
 
--record('$global',
+-record(pickle_global,
         {module :: binary(),                    % module name, eg "__builtin__"
          name:: binary()}).                     % obj name, eg "filter"
 
--record('$object',
-        {class :: #'$global'{},           % class
+-record(pickle_object,
+        {class :: #pickle_global{},        % class
          new_args :: tuple(),              % args for __new__()
          state :: dict() | tuple()}).      % __dict__ or args for __setstate__()
+
+-record(pickle_unicode,
+        {value :: binary()}).

--- a/src/epryl_pickle.erl
+++ b/src/epryl_pickle.erl
@@ -273,7 +273,7 @@ step_machine(Mach, <<16#81, Rest/binary>>) ->
 %% BUILD
 step_machine(Mach, <<$b, Rest/binary>>) ->
     [State, Object | Stack1] = Mach#mach.stack,
-    NewStack = [Object#'$object'{state=State} | Stack1],
+    NewStack = [Object#'$object'{state=finalize(State)} | Stack1],
     {Mach#mach{stack=NewStack}, Rest};
 
 %% BINUNICODE


### PR DESCRIPTION
Support for python objects, global objects (eg, classes, functions etc) and unicode strings added
Parsing only! No serialization.
See tests for examples.

Maybe it will be better to rename record names to smth like `#pickle_object{} #pickle_global{}` ?
